### PR TITLE
[feature] add discord auth and dashboard improvements

### DIFF
--- a/docker/multi-bot/web/static/js/dashboard.js
+++ b/docker/multi-bot/web/static/js/dashboard.js
@@ -373,9 +373,10 @@ class GrugThinkDashboard {
                     <div class="token-meta">Added: ${new Date(token.added_at * 1000).toLocaleDateString()}</div>
                 </div>
                 <div>
-                    <span class="badge ${token.active ? 'bg-success' : 'bg-secondary'}">
-                        ${token.active ? 'Active' : 'Inactive'}
-                    </span>
+                    <span class="badge ${token.active ? 'bg-success' : 'bg-secondary'}">${token.active ? 'Active' : 'Inactive'}</span>
+                    <button class="btn btn-sm btn-danger ms-2" onclick="dashboard.deleteDiscordToken('${token.id}')">
+                        <i class="bi bi-trash"></i>
+                    </button>
                 </div>
             `;
             container.appendChild(item);
@@ -409,6 +410,18 @@ class GrugThinkDashboard {
             this.loadTokens();
         } catch (error) {
             this.showAlert('Failed to add Discord token', 'danger');
+        }
+    }
+
+    async deleteDiscordToken(tokenId) {
+        if (!confirm('Delete this token?')) return;
+
+        try {
+            await this.apiCall(`/discord-tokens/${tokenId}`, { method: 'DELETE' });
+            this.showAlert('Token removed', 'success');
+            this.loadTokens();
+        } catch (error) {
+            this.showAlert('Failed to remove token', 'danger');
         }
     }
 
@@ -609,6 +622,7 @@ class GrugThinkDashboard {
 // Global functions for onclick handlers
 window.createBot = () => dashboard.createBot();
 window.refreshDashboard = () => dashboard.refreshDashboard();
+window.deleteToken = (id) => dashboard.deleteDiscordToken(id);
 
 // Initialize dashboard when page loads
 let dashboard;

--- a/src/grugthink/bot_manager.py
+++ b/src/grugthink/bot_manager.py
@@ -185,12 +185,20 @@ class BotManager:
             "last_heartbeat": instance.last_heartbeat,
             "guild_count": 0,
             "user_count": 0,
+            "guild_ids": [],
+            "user_ids": [],
         }
 
         # Add runtime info if bot is running
         if instance.client and instance.client.is_ready():
-            status["guild_count"] = len(instance.client.guilds)
-            status["user_count"] = sum(guild.member_count for guild in instance.client.guilds)
+            status["guild_ids"] = [g.id for g in instance.client.guilds]
+            users = set()
+            for g in instance.client.guilds:
+                for m in getattr(g, "members", []):
+                    users.add(m.id)
+            status["user_ids"] = list(users)
+            status["guild_count"] = len(status["guild_ids"])
+            status["user_count"] = len(users)
             status["latency"] = round(instance.client.latency * 1000, 2)  # ms
 
         return status
@@ -265,6 +273,8 @@ class BotManager:
             # Create Discord client
             intents = discord.Intents.default()
             intents.message_content = True
+            intents.guilds = True
+            intents.members = True
 
             client = commands.Bot(command_prefix="/", intents=intents, loop=asyncio.get_running_loop())
             instance.client = client

--- a/src/grugthink/config_manager.py
+++ b/src/grugthink/config_manager.py
@@ -330,6 +330,17 @@ class ConfigManager:
 
         return token_entry["id"]
 
+    def remove_discord_token(self, token_id: str) -> bool:
+        """Remove a Discord bot token by ID."""
+        tokens = self.get_config("api_keys.discord.tokens") or []
+        for idx, token in enumerate(tokens):
+            if token["id"] == token_id:
+                tokens.pop(idx)
+                self.set_config("api_keys.discord.tokens", tokens)
+                log.info("Removed Discord token", extra={"token_id": token_id})
+                return True
+        return False
+
     def get_discord_tokens(self) -> List[Dict[str, Any]]:
         """Get all Discord tokens."""
         return self.get_config("api_keys.discord.tokens") or []


### PR DESCRIPTION
## Summary
- add Discord OAuth-based authentication in API server
- require admin session for management endpoints
- track recent logs in memory and expose via API
- return unique guild/user counts
- add token delete API and button on dashboard

## Testing
- `ruff format src/grugthink/api_server.py src/grugthink/bot_manager.py src/grugthink/config_manager.py`
- `ruff check src/grugthink/api_server.py src/grugthink/bot_manager.py src/grugthink/config_manager.py`
- `pip-audit` *(fails: found vulnerabilities)*
- `PYTHONPATH=. pytest` *(fails: ModuleNotFoundError: 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_6862302d6fb483329fd43b81ec97ec80